### PR TITLE
Improve decoder performance on sql calls

### DIFF
--- a/app/lib/sqlalchemy_plugin.py
+++ b/app/lib/sqlalchemy_plugin.py
@@ -61,19 +61,22 @@ See [`async_sessionmaker()`][sqlalchemy.ext.asyncio.async_sessionmaker].
 
 @event.listens_for(engine.sync_engine, "connect")
 def _sqla_on_connect(dbapi_connection: Any, _: Any) -> Any:
-    """Using orjson for serialization of the json column values means that the
+    """Using msgspec for serialization of the json column values means that the
     output is binary, not `str` like `json.dumps` would output.
 
     SQLAlchemy expects that the json serializer returns `str` and calls
     `.encode()` on the value to turn it to bytes before writing to the
-    JSONB column. I'd need to either wrap `orjson.dumps` to return a
-    `str` so that SQLAlchemy could then convert it to binary, or do the
-    following, which changes the behaviour of the dialect to expect a
-    binary value from the serializer.
+    JSONB column. I'd need to do the following, which changes the behaviour 
+    of the dialect to expect a binary value from the serializer.
 
     See Also:
     https://github.com/sqlalchemy/sqlalchemy/blob/14bfbadfdf9260a1c40f63b31641b27fe9de12a0/lib/sqlalchemy/dialects/postgresql/asyncpg.py#L934
     """
+
+    # Create Decoder once and reuse it for all encoding calls, 
+    # to avoid paying setup cost for every call. More info:
+    # https://jcristharif.com/msgspec/perf-tips.html#reuse-encoders-decoders
+    _decoder = msgspec.json.Decoder()
 
     def encoder(bin_value: bytes) -> bytes:
         # \x01 is the prefix for jsonb used by PostgreSQL.
@@ -83,7 +86,7 @@ def _sqla_on_connect(dbapi_connection: Any, _: Any) -> Any:
     def decoder(bin_value: bytes) -> Any:
         # the byte is the \x01 prefix for jsonb used by PostgreSQL.
         # asyncpg returns it when format='binary'
-        return msgspec.json.decode(bin_value[1:])
+        return _decoder.decode(bin_value[1:])
 
     dbapi_connection.await_(
         dbapi_connection.driver_connection.set_type_codec(


### PR DESCRIPTION
- replaced `orjson` tip with `msgspec`
- improved `msgspec` decode performance